### PR TITLE
feat: support auto about.oneself.map

### DIFF
--- a/layout/partial/compoment/about/other.ejs
+++ b/layout/partial/compoment/about/other.ejs
@@ -26,10 +26,15 @@
         }
       });
     </script>
-
+<style>
+    :root {
+        --site-about-oneself-map--light: url(<%= site.data.about.oneself.map.light %>);
+        --site-about-oneself-map--dark: url(<%= site.data.about.oneself.map.dark %>);
+    }
+</style>
 <% const oneself = site.data.about.oneself; %>
 <div class="author-content-item-group column mapAndInfo">
-    <div class="author-content-item map single" style="background: url(<%= oneself.map %> )">
+    <div class="author-content-item map single">
       <span class="map-title">我现在住在 <b><%= oneself.location %></b></span></div>
     <div class="author-content-item selfInfo single">
       <div><span class="selfInfo-title">生于</span><span class="selfInfo-content" style="color: #43a6c6;"><%= oneself.birthYear %></span></div>

--- a/source/css/main.css
+++ b/source/css/main.css
@@ -12570,13 +12570,15 @@ a.bb-link-info:hover {
 
 .author-content-item-group.column.mapAndInfo {
   width: 59%;
+  height: max-content;
 }
 
 /* 关于页面地图 */
 
 .author-content-item.map {
-  background-repeat: no-repeat ;  
-  background-position: center ;
+  background-image: var(--site-about-oneself-map--light);
+  background-repeat: no-repeat;
+  background-position: center;
   min-height: 160px;
   max-height: 400px;
   position: relative;
@@ -12588,9 +12590,10 @@ a.bb-link-info:hover {
 }
 
 [data-theme=dark] .author-content-item.map {
+  background-image: var(--site-about-oneself-map--dark);
   background-size: 100% ;
-  background-repeat: no-repeat ;  
-  background-position: center ;
+  background-repeat: no-repeat;
+  background-position: center;
 }
 
 .author-content-item.map:hover {


### PR DESCRIPTION
* 修复小屏幕下个人介绍模块中 selfInfo 文字偏下的CSS问题
* 新增对个人介绍模块中，城市地图的双模式支持。

**about.yml** 中新增以下配置
```
oneself:
  map:
    light: /images/about/map-light.png
    dark: /images/about/map-dark.png
```